### PR TITLE
Migrate to pcre-heavy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - run:
           command: apt update
       - run:
-          command: apt install -y libicu-dev
+          command: apt install -y libpcre3-dev
       - run:
           command: cabal update
       - run:

--- a/LaTeX-numbers.cabal
+++ b/LaTeX-numbers.cabal
@@ -19,9 +19,9 @@ library
   hs-source-dirs:      src
   build-depends:       base >=4.12
                      , text >=1.2
-                     , text-regex-replace
-                     , text-icu
+                     , pcre-heavy
                      , split
+                     , string-conversions
   default-language:    Haskell2010
 
 executable LaTeX-numbers
@@ -34,7 +34,7 @@ executable LaTeX-numbers
                      , turtle
                      , system-filepath
                      , foldl
-                     , text-icu
+                     , pcre-heavy
   default-language:    Haskell2010
 
 test-suite doctests

--- a/src/LaTeX/Executor.hs
+++ b/src/LaTeX/Executor.hs
@@ -21,8 +21,9 @@ mathApply dict mathDict = foldMap integer1NormalUpdate . foldl1 (\f g x -> f x >
               -- FIXME. Should be composed in another way.
               , return . clearFormatting
               , markMathMode . fractionalMathUpdate . fractionalNormalUpdate
-              , markMathMode . timeLongUpdate
-              , markMathMode . timeShortUpdate
+              , markMathMode . timeMsUpdate
+              , markMathMode . timeSUpdate
+              , markMathMode . timeMUpdate
               , markMathMode . integer5MathUpdate . integer5NormalUpdate
               , markMathMode . integer4MathUpdate . integer4NormalUpdate
               , markMathMode . integer3MathUpdate . integer3NormalUpdate

--- a/src/LaTeX/Executor.hs
+++ b/src/LaTeX/Executor.hs
@@ -21,8 +21,8 @@ mathApply dict mathDict = foldMap integer1NormalUpdate . foldl1 (\f g x -> f x >
               -- FIXME. Should be composed in another way.
               , return . clearFormatting
               , markMathMode . fractionalMathUpdate . fractionalNormalUpdate
-              , markMathMode . timeShortUpdate
               , markMathMode . timeLongUpdate
+              , markMathMode . timeShortUpdate
               , markMathMode . integer5MathUpdate . integer5NormalUpdate
               , markMathMode . integer4MathUpdate . integer4NormalUpdate
               , markMathMode . integer3MathUpdate . integer3NormalUpdate

--- a/src/LaTeX/Replacement/Procedures.hs
+++ b/src/LaTeX/Replacement/Procedures.hs
@@ -57,6 +57,8 @@ mathSpecialReplacement mode =
 -- "$11:21$"
 -- >>> commonReplacement NormalMode timeLongRep "11:21:22"
 -- "$11:21:22$"
+-- >>> commonReplacement NormalMode timeMilliRep "11:21:22:111"
+-- "$11:21:22:111$"
 -}
 commonReplacement :: Mode -> ReplacementData -> Text -> Text
 commonReplacement mode rep = replaceAll (modifier mode rep)
@@ -117,13 +119,17 @@ clearFormattingInner :: Text -> Text
 clearFormattingInner = replaceAll spaceRep
                      . replaceAll commaRep
 
-timeLongUpdate :: Tagged Text -> Tagged Text
-timeLongUpdate (Tagged txt NormalMode) = Tagged (commonReplacement NormalMode timeLongRep txt) NormalMode
-timeLongUpdate a = a
+timeMsUpdate :: Tagged Text -> Tagged Text
+timeMsUpdate (Tagged txt NormalMode) = Tagged (commonReplacement NormalMode timeMsRep txt) NormalMode
+timeMsUpdate a = a
 
-timeShortUpdate :: Tagged Text -> Tagged Text
-timeShortUpdate (Tagged txt NormalMode) = Tagged (commonReplacement NormalMode timeShortRep txt) NormalMode
-timeShortUpdate a = a
+timeSUpdate :: Tagged Text -> Tagged Text
+timeSUpdate (Tagged txt NormalMode) = Tagged (commonReplacement NormalMode timeSRep txt) NormalMode
+timeSUpdate a = a
+
+timeMUpdate :: Tagged Text -> Tagged Text
+timeMUpdate (Tagged txt NormalMode) = Tagged (commonReplacement NormalMode timeMRep txt) NormalMode
+timeMUpdate a = a
 
 integer1NormalUpdate :: Tagged Text -> Tagged Text
 integer1NormalUpdate = integerUpdateInner NormalMode integer1Rep

--- a/src/LaTeX/Replacement/Procedures.hs
+++ b/src/LaTeX/Replacement/Procedures.hs
@@ -5,7 +5,8 @@ module LaTeX.Replacement.Procedures where
 import Data.Monoid ((<>))
 
 import Data.Text (Text)
-import Data.Text.ICU.Replace (replaceAll)
+
+import Text.Regex.PCRE.Heavy
 
 import LaTeX.Replacement.Rules
 import LaTeX.Types
@@ -14,16 +15,16 @@ import LaTeX.Types
 -- >>> :set -XOverloadedStrings
 
 toMathMode :: ReplacementData -> ReplacementData
-toMathMode Replacement{..} = Replacement replacementPattern ("$$" <> replacementResult <> "$$")
+toMathMode Replacement{..} = Replacement replacementPattern ((\s -> "$" <> s <> "$") . replacementResult)
 
 toItalic :: ReplacementData -> ReplacementData
-toItalic Replacement{..} = Replacement replacementPattern ("$$ \\mathit{" <> replacementResult <> "} $$")
+toItalic Replacement{..} = Replacement replacementPattern ((\s -> "$ \\mathit{" <> s <> "} $") . replacementResult)
 
 toBold :: ReplacementData -> ReplacementData
-toBold Replacement{..} = Replacement replacementPattern ("$$ \\mathbf{" <> replacementResult <> "} $$")
+toBold Replacement{..} = Replacement replacementPattern ((\s -> "$ \\mathbf{" <> s <> "} $") . replacementResult)
 
-replaceAll_ :: ReplacementData -> Text -> Text
-replaceAll_ Replacement{..} = replaceAll replacementPattern replacementResult
+replaceAll :: ReplacementData -> Text -> Text
+replaceAll Replacement{..} = gsub replacementPattern replacementResult
 
 modifier :: Mode -> ReplacementData -> ReplacementData
 modifier MathMode = id
@@ -42,8 +43,8 @@ modifier Bold = toBold
 -}
 mathSpecialReplacement :: Mode -> Text -> Text
 mathSpecialReplacement mode =
-    replaceAll_ (modifier mode mathBracketsRep)
-  . replaceAll_ (modifier mode mathDollarsRep)
+    replaceAll (modifier mode mathBracketsRep)
+  . replaceAll (modifier mode mathDollarsRep)
 
 {- $
 -- >>> commonReplacement MathMode integer2Rep "1 22 334 4444 55555 666666 7777777 32,34"
@@ -58,7 +59,7 @@ mathSpecialReplacement mode =
 -- "$11:21:22$"
 -}
 commonReplacement :: Mode -> ReplacementData -> Text -> Text
-commonReplacement mode rep = replaceAll_ (modifier mode rep)
+commonReplacement mode rep = replaceAll (modifier mode rep)
 
 {- $
 -
@@ -69,7 +70,7 @@ commonReplacement mode rep = replaceAll_ (modifier mode rep)
 -- "$1{,}23$ $1{,}23$ 1{,}23 $1{,}34555$ $1111{,}23$ $111\\,111{,}3$ 1111111{,}3 $1\\,111\\,111{,}3$ d,d"
 -}
 fractionalReplacement :: Mode -> Text -> Text
-fractionalReplacement mode = foldr1 (.) $ map (\rep -> replaceAll_ (modifier mode rep)) reps
+fractionalReplacement mode = foldr1 (.) $ map (\rep -> replaceAll (modifier mode rep)) reps
   where
     reps = [ fractional1_1Rep, fractional2_1Rep, fractional1_2Rep
            , fractional1_3Rep, fractional3_1Rep, fractional2_2Rep
@@ -113,8 +114,8 @@ clearFormatting a = a
 -- >>> clearFormattingInner "11{,}21 11{,}2 22{,}2 2{,} 2,2 d{,}d 2\\,2 a\\,2 \\, {,} , 2\\, \\,2"
 -- "11,21 11,2 22,2 2{,} 2,2 d{,}d 22 a\\,2 \\, {,} , 2\\, \\,2"
 clearFormattingInner :: Text -> Text
-clearFormattingInner = replaceAll_ spaceRep
-                     . replaceAll_ commaRep
+clearFormattingInner = replaceAll spaceRep
+                     . replaceAll commaRep
 
 timeLongUpdate :: Tagged Text -> Tagged Text
 timeLongUpdate (Tagged txt NormalMode) = Tagged (commonReplacement NormalMode timeLongRep txt) NormalMode

--- a/src/LaTeX/Replacement/Rules.hs
+++ b/src/LaTeX/Replacement/Rules.hs
@@ -1,70 +1,103 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
 module LaTeX.Replacement.Rules where
 
-import Data.Text.ICU (Regex)
-import Data.Text.ICU.Replace (Replace)
+import Data.Text (Text)
 
-data ReplacementData = Replacement {
-    replacementPattern :: Regex
-  , replacementResult  :: Replace
-  }
+import Text.Regex.PCRE.Heavy
+
+import LaTeX.Types
 
 commaRep :: ReplacementData
-commaRep = Replacement "(\\d)\\{,\\}(\\d)" "$1,$2"
+commaRep = Replacement
+  [re|(\d)\{,\}(\d)|]
+  (\(s1:s2:_) -> s1 <> "," <> s2)
 
 spaceRep :: ReplacementData
-spaceRep = Replacement "(\\d)\\\\,(\\d)" "$1$2"
+spaceRep = Replacement
+  [re|(\d)\\,(\d)|]
+  (\(s1:s2:_) -> s1 <> s2)
 
 fractional3_3Rep :: ReplacementData
-fractional3_3Rep = Replacement "(\\d{1,3})~*(\\d{3})~*(\\d{3})[\\.,](\\d{1,3})~*(\\d{3})~*(\\d{3})" "$1\\,$2\\,$3{,}$4$5$6"
+fractional3_3Rep = Replacement
+  [re|(\d{1,3})~*(\d{3})~*(\d{3})[\.,](\d{1,3})~*(\d{3})~*(\d{3})|]
+  (\(s1:s2:s3:s4:s5:s6:_) -> s1 <> "\\," <> s2 <> "\\," <> s3 <> "{,}" <> s4 <> s5 <> s6)
 
 fractional2_3Rep :: ReplacementData
-fractional2_3Rep = Replacement "(\\d{1,3})~*(\\d{3})[\\.,](\\d{1,3})~*(\\d{3})~*(\\d{3})" "$1\\,$2{,}$3$4$5"
+fractional2_3Rep = Replacement
+  [re|(\d{1,3})~*(\d{3})[\.,](\d{1,3})~*(\d{3})~*(\d{3})|]
+  (\(s1:s2:s3:s4:s5:_) -> s1 <> "\\," <> s2 <> "{,}" <> s3 <> s4 <> s5)
 
 fractional1_3Rep :: ReplacementData
-fractional1_3Rep = Replacement "(\\d{1,3})[\\.,](\\d{1,3})~*(\\d{3})~*(\\d{3})" "$1{,}$3$4$5"
+fractional1_3Rep = Replacement
+  [re|(\d{1,3})[\.,](\d{1,3})~*(\d{3})~*(\d{3})|]
+  (\(s1:s2:s3:s4:_) -> s1 <> "{,}" <> s2 <> s3 <> s4)
 
 fractional3_2Rep :: ReplacementData
-fractional3_2Rep = Replacement "(\\d{1,3})~*(\\d{3})~*(\\d{3})[\\.,](\\d{1,3})~*(\\d{3})" "$1\\,$2\\,$3{,}$4$5"
+fractional3_2Rep = Replacement
+  [re|(\d{1,3})~*(\d{3})~*(\d{3})[\.,](\d{1,3})~*(\d{3})|]
+  (\(s1:s2:s3:s4:s5:_) -> s1 <> "\\," <> s2 <> "\\," <> s3 <> "{,}" <> s4 <> s5)
 
 fractional3_1Rep :: ReplacementData
-fractional3_1Rep = Replacement "(\\d{1,3})~*(\\d{3})~*(\\d{3})[\\.,](\\d{1,3})" "$1\\,$2\\,$3{,}$4"
+fractional3_1Rep = Replacement
+  [re|(\d{1,3})~*(\d{3})~*(\d{3})[\.,](\d{1,3})|]
+  (\(s1:s2:s3:s4:_) -> s1 <> "\\," <> s2 <> "\\," <> s3 <> "{,}" <> s4)
 
 fractional2_2Rep :: ReplacementData
-fractional2_2Rep = Replacement "(\\d{1,3})~*(\\d{3})[\\.,](\\d{1,3})~*(\\d{3})" "$1\\,$2{,}$3$4"
+fractional2_2Rep = Replacement
+  [re|(\d{1,3})~*(\d{3})[\.,](\d{1,3})~*(\d{3})|]
+  (\(s1:s2:s3:s4:_) -> s1 <> "\\," <> s2 <> "{,}" <> s3 <> s4)
 
 fractional2_1Rep :: ReplacementData
-fractional2_1Rep = Replacement "(\\d{1,3})[\\.,](\\d{1,3})~*(\\d{3})" "$1{,}$2$3"
+fractional2_1Rep = Replacement
+  [re|(\d{1,3})[\.,](\d{1,3})~*(\d{3})|]
+  (\(s1:s2:s3:_) -> s1 <> "{,}" <> s2 <> s3)
 
 fractional1_2Rep :: ReplacementData
-fractional1_2Rep = Replacement "(\\d{2,3})~*(\\d{3})[\\.,](\\d{1,3})" "$1\\,$2{,}$3"
+fractional1_2Rep = Replacement
+  [re|(\d{2,3})~*(\d{3})[\.,](\d{1,3})|]
+  (\(s1:s2:s3:_) -> s1 <> "\\," <> s2 <> "{,}" <> s3)
 
 fractional1_1Rep :: ReplacementData
-fractional1_1Rep = Replacement "(\\d{1,4})[\\.,](\\d{1,3})" "$1{,}$2"
+fractional1_1Rep = Replacement
+  [re|(\d{1,4})[\.,](\d{1,3})|]
+  (\(s1:s2:_) -> s1 <> "{,}" <> s2)
 
 timeShortRep :: ReplacementData
-timeShortRep = Replacement "(\\d{1,2}):(\\d{1,2})" "$1:$2"
+timeShortRep = Replacement
+  [re|(\d{1,2}):(\d{1,2})|]
+  (\(s1:s2:_) -> s1 <> ":" <> s2)
 
 timeLongRep :: ReplacementData
-timeLongRep = Replacement "(\\d{1,2}):(\\d{1,2}):(\\d{1,2})" "$1:$2:$3"
- 
+timeLongRep = Replacement
+  [re|(\d{1,2}):(\d{1,2}):(\d{1,2})|]
+  (\(s1:s2:s3:_) -> s1 <> ":" <> s2 <> ":" <> s3)
+
 integer5Rep :: ReplacementData
-integer5Rep = Replacement "(\\d{1,3})~*(\\d{3})~*(\\d{3})~*(\\d{3})~*(\\d{3})" "$1\\,$2\\,$3\\,$4\\,$5"
- 
+integer5Rep = Replacement
+  [re|(\d{1,3})~*(\d{3})~*(\d{3})~*(\d{3})~*(\d{3})|]
+  (\(s1:s2:s3:s4:s5:_) -> s1 <> "\\," <> s2 <> "\\," <> s3 <> "\\," <> s4 <> "\\," <> s5)
+
 integer4Rep :: ReplacementData
-integer4Rep = Replacement "(\\d{1,3})~*(\\d{3})~*(\\d{3})~*(\\d{3})" "$1\\,$2\\,$3\\,$4"
- 
+integer4Rep = Replacement
+  [re|(\d{1,3})~*(\d{3})~*(\d{3})~*(\d{3})|]
+  (\(s1:s2:s3:s4:_) -> s1 <> "\\," <> s2 <> "\\," <> s3 <> "\\," <> s4)
+
 integer3Rep :: ReplacementData
-integer3Rep = Replacement "(\\d{1,3})~*(\\d{3})~*(\\d{3})" "$1\\,$2\\,$3"
- 
+integer3Rep = Replacement
+  [re|(\d{1,3})~*(\d{3})~*(\d{3})|]
+  (\(s1:s2:s3:_) -> s1 <> "\\," <> s2 <> "\\," <> s3)
+
 integer2Rep :: ReplacementData
-integer2Rep = Replacement "(\\d{2,3})~*(\\d{3})" "$1\\,$2"
- 
+integer2Rep = Replacement
+  [re|(\d{2,3})~*(\d{3})|]
+  (\(s1:s2:_) -> s1 <> "\\," <> s2)
+
 integer1Rep :: ReplacementData
-integer1Rep = Replacement "(\\d{1,4})" "$1"
+integer1Rep = Replacement [re|(\d{1,4})|] head
 
 mathBracketsRep :: ReplacementData
-mathBracketsRep = Replacement "\\\\\\((.*?)\\\\\\)" "$1"
+mathBracketsRep = Replacement [re|\\\((.*?)\\\)|] head
 
 mathDollarsRep :: ReplacementData
-mathDollarsRep = Replacement "\\$(.*?)\\$" "$1"
+mathDollarsRep = Replacement [re|\$(.*?)\$|] head

--- a/src/LaTeX/Replacement/Rules.hs
+++ b/src/LaTeX/Replacement/Rules.hs
@@ -63,13 +63,18 @@ fractional1_1Rep = Replacement
   [re|(\d{1,4})[\.,](\d{1,3})|]
   (\(s1:s2:_) -> s1 <> "{,}" <> s2)
 
-timeShortRep :: ReplacementData
-timeShortRep = Replacement
+timeMRep :: ReplacementData
+timeMRep = Replacement
   [re|(\d{1,2}):(\d{1,2})|]
   (\(s1:s2:_) -> s1 <> ":" <> s2)
 
-timeLongRep :: ReplacementData
-timeLongRep = Replacement
+timeMsRep :: ReplacementData
+timeMsRep = Replacement
+  [re|(\d{1,2}):(\d{1,2}):(\d{1,2}):(\d{1,3})|]
+  (\(s1:s2:s3:s4:_) -> s1 <> ":" <> s2 <> ":" <> s3 <> ":" <> s4)
+
+timeSRep :: ReplacementData
+timeSRep = Replacement
   [re|(\d{1,2}):(\d{1,2}):(\d{1,2})|]
   (\(s1:s2:s3:_) -> s1 <> ":" <> s2 <> ":" <> s3)
 

--- a/src/LaTeX/Types.hs
+++ b/src/LaTeX/Types.hs
@@ -1,26 +1,33 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
 module LaTeX.Types where
 
 import Data.Semigroup
 
 import Data.Text (Text)
 import qualified Data.Text as T
-import Data.Text.ICU (Regex)
+
+import Text.Regex.PCRE.Heavy
+
+data ReplacementData = Replacement {
+    replacementPattern :: Regex
+  , replacementResult  :: [Text] -> Text
+  }
 
 newtype Dictionary = Dictionary [Regex] deriving (Show, Semigroup, Monoid)
 
 -- No replacements in comments.
-defaultCmdDictionary = Dictionary ["(%.*)"]
+defaultCmdDictionary = Dictionary [[re|(%.*)|]]
 
 -- $$, \(\)
-defaultMathModeDictionary = Dictionary ["(\\$.*?\\$)","(\\\\\\(.*?\\\\\\))"]
+defaultMathModeDictionary = Dictionary [[re|(\$.*?\$)|],[re|(\\\(.*?\\\))|]]
 
 -- \textbf{}
-boldDictionary = Dictionary ["(\\\\textbf\\{.*?\\})"]
+boldDictionary = Dictionary [[re|(\\textbf\{.*?\})|]]
 
 -- \textit{}
-italicDictionary = Dictionary ["(\\\\textit\\{.*?\\})"]
+italicDictionary = Dictionary [[re|(\\textit\{.*?\})|]]
 
 data Trimmed = Trimmed {
     trimmedHead :: Text


### PR DESCRIPTION
Probably will close #24 
Partly covers #26 with milliseconds precision time.

Adds dependency on `libpcre3`. Awaiting usability tests.